### PR TITLE
Fix docs of installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ let g:ctrlp_match_func = {'match': 'ctrlp_matchfuzzy#matcher'}
 For [vim-plug](https://github.com/junegunn/vim-plug) plugin manager:
 
 ```
-Plug 'ctrlp-matchfuzzy'
+Plug 'mattn/ctrlp-matchfuzzy'
 ```
 
 ## License


### PR DESCRIPTION
When I type the installation command in the README, I got an error.

```
[vim-plug] ctrlp-matchfuzzy Invalid argument: ctrlp-matchfuzzy (implicit `vim-scripts' expansion is deprecated)
Press ENTER or type command to continue
```

I've tried to fix the installation command.